### PR TITLE
Implement configuration file parsing and handling

### DIFF
--- a/dyficlient/client.go
+++ b/dyficlient/client.go
@@ -52,8 +52,8 @@ func CheckIP() []byte {
 
 // UpdateIP sends a refresh request to the dy.fi server to update current IP address
 // pointing to a hostname. Returns the response body and status as a string.
-func UpdateIP(username *string, password *string, hostname *string, email *string) ([]byte, string) {
-    updateIPURL := updateIPBaseURL + *hostname
+func UpdateIP(username string, password string, hostname string, email string) ([]byte, string) {
+    updateIPURL := updateIPBaseURL + hostname
 
     log.Printf(updateIPURL + "\n")
     request, err := http.NewRequest("GET", updateIPURL, nil)
@@ -62,8 +62,8 @@ func UpdateIP(username *string, password *string, hostname *string, email *strin
         log.Fatal(err)
     }
 
-    request.SetBasicAuth(*username, *password)
-    request.Header.Set("User-Agent", "redyfi/0.0.3 ("+*email+")")
+    request.SetBasicAuth(username, password)
+    request.Header.Set("User-Agent", "redyfi/0.0.3 ("+email+")")
 
     client := &http.Client{}
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/user"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -18,7 +20,7 @@ type configs struct {
 	Email    string
 }
 
-var configPathDefaults = [...]string{
+var configPathDefaults = []string{
 	"Redyfi.json",
 	"/etc/redyfi/Redyfi.json",
 }
@@ -41,6 +43,14 @@ func readAndParseConfig(path *string, config *configs) error {
 
 func main() {
 
+	usr, err := user.Current()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	configPathDefaults = append(configPathDefaults, filepath.Join(usr.HomeDir, ".redyfi", "Redyfi.json"))
+
 	flag.String("username", "", "dy.fi username")
 	flag.String("password", "", "dy.fi password")
 	flag.String("hostname", "", "hostname to update")
@@ -61,6 +71,7 @@ func main() {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				continue
 			}
+
 			if err := readAndParseConfig(configPath, config); err != nil {
 				log.Fatal(err)
 			}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,41 @@
 package main
 
 import (
+    "encoding/json"
     "flag"
     "log"
+    "os"
 
     "github.com/anerani/redyfi/dyficlient"
 )
+
+type configs struct {
+    Username string
+    Password string
+    Hostname string
+    Email    string
+}
+
+var configPathDefaults = [...]string{
+    "Redyfi.json",
+    "/etc/redyfi/Redyfi.json",
+}
+
+func readAndParseConfig(path *string, config *configs) error {
+    fileHandle, err := os.Open(*path)
+    if err != nil {
+        return err
+    }
+
+    jsonDecoder := json.NewDecoder(fileHandle)
+
+    err = jsonDecoder.Decode(&config)
+
+    if err != nil {
+        return err
+    }
+    return nil
+}
 
 func main() {
 
@@ -13,14 +43,48 @@ func main() {
     password := flag.String("password", "", "dy.fi password")
     hostname := flag.String("hostname", "", "hostname to update")
     email := flag.String("mail", "", "email address for user agent header")
+    configPath := flag.String("configPath", "", "path to a configuration file")
+
     flag.Parse()
+
+    config := &configs{}
+
+    if *configPath != "" {
+        if err := readAndParseConfig(configPath, config); err != nil {
+            log.Fatal(err)
+        }
+    } else {
+        for _, path := range configPathDefaults {
+
+            if _, err := os.Stat(path); os.IsNotExist(err) {
+                continue
+            }
+            if err := readAndParseConfig(configPath, config); err != nil {
+                log.Fatal(err)
+            }
+            break
+        }
+    }
+
+    if *username != "" {
+        config.Username = *username
+    }
+    if *password != "" {
+        config.Password = *password
+    }
+    if *hostname != "" {
+        config.Hostname = *hostname
+    }
+    if *email != "" {
+        config.Email = *email
+    }
 
     IPAddr := dyficlient.CheckIP()
 
     log.Printf("Seems like current IP address is: %s\n", IPAddr)
     log.Printf("Attempting to update...")
 
-    responseBody, responseStatus := dyficlient.UpdateIP(username, password, hostname, email)
+    responseBody, responseStatus := dyficlient.UpdateIP(config.Username, config.Password, config.Hostname, config.Email)
 
     log.Printf("Response status: %s\n", responseStatus)
     log.Printf("Response body: %s\n", responseBody)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.String("username", "", "dy.fi username")
 	flag.String("password", "", "dy.fi password")
 	flag.String("hostname", "", "hostname to update")
-	flag.String("mail", "", "email address for user agent header")
+	flag.String("email", "", "email address for user agent header")
 	configPath := flag.String("configPath", "", "path to a configuration file")
 
 	flag.Parse()
@@ -87,6 +87,19 @@ func main() {
 
 		field.SetString(value)
 	})
+
+	// all options are required (at least at the moment)
+	// so check that all options have values
+	structType := structReflection.Type()
+
+	for i := 0; i < structReflection.NumField(); i++ {
+		fieldInterface := structReflection.Field(i).Interface()
+
+		if fieldInterface == reflect.Zero(reflect.TypeOf(fieldInterface)).Interface() {
+			flag.Usage()
+			log.Fatalf("Missing a command line argument for: %s", structType.Field(i).Name)
+		}
+	}
 
 	IPAddr := dyficlient.CheckIP()
 

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 
 		if fieldInterface == reflect.Zero(reflect.TypeOf(fieldInterface)).Interface() {
 			flag.Usage()
-			log.Fatalf("Missing a command line argument for: %s", structType.Field(i).Name)
+			log.Fatalf("Missing an argument for: %s", structType.Field(i).Name)
 		}
 	}
 


### PR DESCRIPTION
This pull request implements a configuration file parsing feature. Fixes issue #1. Logic also works in such a way that CLI arguments will override those given in a configuration file. Default locations to read the file are current folder from which the binary is being executed, and ```/etc/redyfi``` and $HOME/.redyfi paths.